### PR TITLE
docs: note Postgres log storage

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -1,0 +1,4 @@
+# Instructions
+
+Logs are stored in Postgres using the logic defined in `backend-mcp/src/db.ts`.
+To persist logs in both Postgres and Redis, extend `backend-mcp/src/db.ts` to also write to a Redis client.


### PR DESCRIPTION
## Summary
- Document Postgres log storage via `backend-mcp/src/db.ts`
- Mention optional Redis persistence for dual storage

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm test` in `mcp-server` *(fails: missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5d33d32108322b96efe4322848737