### PR TITLE
Use NEXT_PUBLIC_WS_URL from import.meta.env

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_WS_URL=ws://localhost:3000

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -1,0 +1,5 @@
+import { io } from 'socket.io-client';
+
+export const socket = io(
+  import.meta.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:3000'
+);


### PR DESCRIPTION
## Summary
- read websocket URL from `import.meta.env.NEXT_PUBLIC_WS_URL`
- add `.env.local.example` exposing `NEXT_PUBLIC_WS_URL`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d348db2083228278cc885df35958