### PR TITLE
Introduce audit log schema and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@
   DATABASE_URL=<your-neon-connection-string>
   ```
 
+### Audit Log Table
+- The `backend/infra/audit_log.sql` file defines a table for tracking job activity.
+- Columns: `job_id`, `agent`, `phase`, `payload`, and a timestamp.
+- Indexes on `job_id` and `agent` speed up lookup by these fields.
+
 ### AI Gateway
-- Install your AI Gateway SDK (example placeholder):
+- Install your AI Gateway SDK:
   ```bash
   npm install ai-gateway-sdk
   ```

--- a/backend/infra/audit_log.sql
+++ b/backend/infra/audit_log.sql
@@ -1,0 +1,13 @@
+-- Schema for auditing job lifecycle events
+CREATE TABLE IF NOT EXISTS audit_log (
+    id SERIAL PRIMARY KEY,
+    job_id TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    phase TEXT,
+    payload JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for common lookup fields
+CREATE INDEX IF NOT EXISTS idx_audit_log_job_id ON audit_log(job_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_agent ON audit_log(agent);


### PR DESCRIPTION
## Summary
- add `audit_log` table with phase and payload for detailed auditing
- index `job_id` and `agent` for quicker lookups
- document audit log setup in README

## Testing
- `pytest`
- `python -m py_compile backend/orchestrator.py backend/infra/init_redis_streams.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5d36fe564832295a499271d3370d3