### PR TITLE
docs: define agent names and workflow

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -3,16 +3,29 @@
 ## Vision
 - Build an orchestrated multi-agent system for analyzing large codebases and reconstructing them.
 
-## Agent Roles
-1. **Manifest Builder** – scans every file and directory to produce a manifest.
-2. **Manifest Verifier** – checks the manifest for accuracy.
-3. **Structure Creator** – creates folders and empty files from the manifest.
-4. **Structure Inspector** – validates the generated structure.
-5. **Orchestrator** – coordinates agents, triggers the next step, and replaces underperforming agents.
+## Agent Roster
+- **Atlas** – Manifest Builder; scans every file and directory to produce a manifest.
+- **Spectra** – Manifest Verifier; checks the manifest for accuracy.
+- **Forge** – Structure Creator; creates folders and empty files from the manifest.
+- **Sentinel** – Structure Inspector; validates the generated structure.
+- **Nexus** – Orchestrator; coordinates agents, triggers the next step, and replaces underperforming agents.
 
 Once structure is ready, agents loop to populate code:
 - Agents sequentially fill each category of files (e.g., utilities, components, index).
-- Orchestrator ensures agents do not collide and re-queues them as they finish.
+- Nexus ensures agents do not collide and re-queues them as they finish.
+
+```mermaid
+flowchart TD
+    subgraph Pipeline
+        A[Atlas\nManifest Builder] --> B[Spectra\nManifest Verifier]
+        B --> C[Forge\nStructure Creator]
+        C --> D[Sentinel\nStructure Inspector]
+    end
+    Nexus[Nexus\nOrchestrator] --> A
+    Nexus --> B
+    Nexus --> C
+    Nexus --> D
+```
 
 ## Interface and Technology
 - Single-page control panel with six chat views (five agents plus orchestrator) and a log stream.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,7 +2,7 @@
 
 - No fallbacks except those inherent to AI Gateway; all other errors must surface immediately.
 - No authentication; the system runs locally for a single user.
-- Agents have distinct futuristic names and singular goals; orchestrator replaces any agent that drifts.
+- Agents have distinct futuristic names and singular goals; **Atlas**, **Spectra**, **Forge**, and **Sentinel** focus only on their assigned phase while **Nexus** replaces any agent that drifts.
 - Execute tasks sequentially to avoid overlap; orchestrator governs timing.
 - Log every action and stream updates in real time to the six-interface dashboard.
 - Provide emergency stop and pause controls.


### PR DESCRIPTION
## Summary
- assign futuristic names to all agents and orchestrator
- document agent workflow with a mermaid diagram
- clarify rules regarding agent responsibilities

## Testing
- `npm test --prefix frontend` *(fails: Cannot find module 'react')*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c60f37d1c883229753eb32b0f6cf43